### PR TITLE
removed test; changed default behavior: won't raise error if file-to-…

### DIFF
--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -77,10 +77,11 @@ class TestDownloadFile():
     def transact(self, tmpdir):
         self.tmpdir = Path(tmpdir)
 
-    def test_raises_if_file_exists_overwrite_false(self, *_args):
-        with pytest.raises(FileExistsError):
-            self.tmpdir.joinpath(self.mock_filename).touch()
-            download_file(self.mock_filename, self.mock_src_url, self.tmpdir, overwrite=False)
+    # NOTE: changed behavior. we want lambda to continue even if the downloaded file already exists.
+    #def test_raises_if_file_exists_overwrite_false(self, *_args):
+    #    with pytest.raises(FileExistsError):
+    #        self.tmpdir.joinpath(self.mock_filename).touch()
+    #        download_file(self.mock_filename, self.mock_src_url, self.tmpdir, overwrite=False)
 
     def test_doesnt_raise_if_file_exists_overwrite_true(self, *_args):
         self.tmpdir.joinpath(self.mock_filename).touch()


### PR DESCRIPTION
…be-downloaded already exists