### PR TITLE
v1.2.2 added --save_control CLI option

### DIFF
--- a/methylprep/cli.py
+++ b/methylprep/cli.py
@@ -176,6 +176,14 @@ def cli_process(cmd_args):
         help="Change the processed beta or m_value data_type output from float64 to float16 or float32, to save disk space.",
     )
 
+    parser.add_argument(
+        '-c', '--save_control',
+        required=False,
+        action='store_true',
+        default=False,
+        help='If specified, saves an additional "control_probes.pkl" file that contains Control and SNP-I probe data in the data_dir.'
+    )
+
     args = parser.parse_args(cmd_args)
 
     array_type = args.array_type
@@ -200,6 +208,7 @@ def cli_process(cmd_args):
         export=args.no_export, # flag flips here
         meta_data_frame=args.no_meta_export, # flag flips here
         bit=args.bit,
+        save_control=args.save_control,
         )
 
 

--- a/methylprep/files/idat.py
+++ b/methylprep/files/idat.py
@@ -39,6 +39,9 @@ class IdatHeaderLocation(IntEnum):
 class IdatSectionCode(IntEnum):
     """Unique IntEnum defining constant values for byte offsets of IDAT headers.
     These values come from the field codes of the Bioconductor illuminaio package.
+
+    MM: refer to https://bioconductor.org/packages/release/bioc/vignettes/illuminaio/inst/doc/EncryptedFormat.pdf
+    and https://bioconductor.org/packages/release/bioc/vignettes/illuminaio/inst/doc/illuminaio.pdf
     """
     ILLUMINA_ID = 102
     STD_DEV = 103
@@ -239,7 +242,7 @@ class IdatDataset():
             data=probe_records,
             orient='index',
             columns=['mean_value'],
-            dtype='float64',
+            dtype='float32',
         )
 
         data_frame.index.name = 'illumina_id'

--- a/methylprep/models/__init__.py
+++ b/methylprep/models/__init__.py
@@ -6,6 +6,8 @@ from .probes import (
     FG_RED_PROBE_SUBSETS,
     METHYLATED_PROBE_SUBSETS,
     UNMETHYLATED_PROBE_SUBSETS,
+    METHYLATED_SNP_PROBES,
+    UNMETHYLATED_SNP_PROBES,
     Channel,
     Probe,
     ProbeAddress,

--- a/methylprep/models/arrays.py
+++ b/methylprep/models/arrays.py
@@ -15,7 +15,7 @@ class ArrayType(Enum):
 
     @classmethod
     def from_probe_count(cls, probe_count):
-        """Determines array type using number of probes. Returns array string."""
+        """Determines array type using number of probes counted in raw idat file. Returns array string."""
         if probe_count == 1055583:
             return cls.ILLUMINA_EPIC_PLUS
 
@@ -36,20 +36,28 @@ class ArrayType(Enum):
             ArrayType.ILLUMINA_27K: 27578,
             ArrayType.ILLUMINA_450K: 485578,
             ArrayType.ILLUMINA_EPIC: 865919,
-            ArrayType.ILLUMINA_EPIC_PLUS: 868699,
+            ArrayType.ILLUMINA_EPIC_PLUS: 868698, # was 868699 until Jan 21, 2020. corrected.
         }
-
         return probe_counts.get(self)
 
     @property
     def num_controls(self):
         probe_counts = {
-            ArrayType.ILLUMINA_27K: 144,
+            ArrayType.ILLUMINA_27K: 144, # the manifest does not contain control probe data (illumina's site included)
             ArrayType.ILLUMINA_450K: 850,
             ArrayType.ILLUMINA_EPIC: 635,
             ArrayType.ILLUMINA_EPIC_PLUS: 635,
         }
+        return probe_counts.get(self)
 
+    @property
+    def num_snps(self):
+        probe_counts = {
+            ArrayType.ILLUMINA_27K: 0,
+            ArrayType.ILLUMINA_450K: 65,
+            ArrayType.ILLUMINA_EPIC: 59,
+            ArrayType.ILLUMINA_EPIC_PLUS: 120,
+        }
         return probe_counts.get(self)
 
 ''' # doesn't appear to be used anywhere. -- and pipeline Array model conflicts with it.

--- a/methylprep/models/probes.py
+++ b/methylprep/models/probes.py
@@ -4,6 +4,8 @@ from enum import Enum, unique
 
 @unique
 class Channel(Enum):
+    """ idat probes measure either a red or green fluorescence.
+    This specifies which to return within idat.py: red_idat or green_idat."""
     RED = 'Red'
     GREEN = 'Grn'
 
@@ -21,6 +23,13 @@ class Channel(Enum):
 
 @unique
 class ProbeAddress(Enum):
+    """AddressA_ID and AddressB_ID are columns in the manifest csv that contain internal Illumina probe identifiers.
+
+    Type II probes use AddressA_ID; Type I uses both, because there are two probes, two colors.
+
+    probe intensities in .idat files are keyed to one of these ids, but processed data is always keyed to the
+    IlmnID probe "names" -- so this is used in converting between IDs. It is used to define probe sets below
+    in this probes.py"""
     A = 'A'
     B = 'B'
 
@@ -33,6 +42,11 @@ class ProbeAddress(Enum):
 
 @unique
 class ProbeType(Enum):
+    """ probes can either be type I or type II for CpG or Snp sequences. Control probes are used for background
+    correction in different fluorescence ranges and staining efficiency.
+    Type I probes record EITHER a red or a green value.
+    Type II probes record both values together.
+    NOOB uses the red fluorescence on a green probe and vice versa to calculate background fluorescence."""
     ONE = 'I'
     TWO = 'II'
     SNP_ONE = 'SnpI'
@@ -44,6 +58,9 @@ class ProbeType(Enum):
 
     @staticmethod
     def from_manifest_values(name, infinium_type):
+        """ this function determines which of four kinds of probe goes with this name, using either
+        the Infinium_Design_Type (I or II) or the name (starts with 'rs')
+        and decides 'Control' is non of the above."""
         is_snp = name.startswith('rs')
 
         if infinium_type == 'I':
@@ -56,6 +73,7 @@ class ProbeType(Enum):
 
 
 class Probe():
+    """ this doesn't appear to be instantiated anywhere in methylprep """
     __slots__ = [
         'address',
         'illumina_id',
@@ -69,6 +87,9 @@ class Probe():
 
 
 class ProbeSubset():
+    """ used below in probes.py to define sub-sets of probes:
+    foreground-(red|green|all), or (un)methylated probes
+    """
     __slots__ = [
         'data_channel',
         'probe_address',
@@ -103,6 +124,81 @@ class ProbeSubset():
             channel=self.probe_channel,
         )
 
+
+'''
+# notebook equivalent of SNP_PROBES below.
+#manifest = data_containers[0].manifest.data_frame
+#snpProbesI = manifest[manifest['probe_type']=='SnpI']
+#snpProbesI_Grn = snpProbesI[snpProbesI['Color_Channel']=='Grn']
+#snpProbesI_Red = snpProbesI[snpProbesI['Color_Channel']=='Red']
+#snpProbesII = manifest[manifest['probe_type']=='SnpII']
+
+SNP_PROBES = (
+    # SNP_II_PROBES
+    ProbeSubset(
+        data_channel=Channel.GREEN,
+        probe_address=ProbeAddress.A,
+        probe_channel=None,
+        probe_type=ProbeType.SNP_TWO,
+    ),
+    # SNP_I_GREEN_PROBES
+    ProbeSubset(
+        data_channel=Channel.GREEN,
+        probe_address=ProbeAddress.A,
+        probe_channel=Channel.GREEN,
+        probe_type=ProbeType.SNP_ONE,
+    ),
+    # SNP_I_RED_PROBES
+    ProbeSubset(
+        data_channel=Channel.RED,
+        probe_address=ProbeAddress.B,
+        probe_channel=Channel.RED,
+        probe_type=ProbeType.SNP_ONE,
+    )
+)
+'''
+
+METHYLATED_SNP_PROBES = (
+    ProbeSubset(
+        data_channel=Channel.GREEN,
+        probe_address=ProbeAddress.A,
+        probe_channel=None,
+        probe_type=ProbeType.SNP_TWO,
+    ),
+    ProbeSubset(
+        data_channel=Channel.GREEN,
+        probe_address=ProbeAddress.B,
+        probe_channel=Channel.GREEN,
+        probe_type=ProbeType.SNP_ONE,
+    ),
+    ProbeSubset(
+        data_channel=Channel.RED,
+        probe_address=ProbeAddress.B,
+        probe_channel=Channel.RED,
+        probe_type=ProbeType.SNP_ONE,
+    ),
+)
+
+UNMETHYLATED_SNP_PROBES = (
+    ProbeSubset(
+        data_channel=Channel.RED,
+        probe_address=ProbeAddress.A,
+        probe_channel=None,
+        probe_type=ProbeType.SNP_TWO,
+    ),
+    ProbeSubset(
+        data_channel=Channel.GREEN,
+        probe_address=ProbeAddress.A,
+        probe_channel=Channel.GREEN,
+        probe_type=ProbeType.SNP_ONE,
+    ),
+    ProbeSubset(
+        data_channel=Channel.RED,
+        probe_address=ProbeAddress.A,
+        probe_channel=Channel.RED,
+        probe_type=ProbeType.SNP_ONE,
+    ),
+)
 
 FG_GREEN_PROBE_SUBSETS = (
     ProbeSubset(

--- a/methylprep/processing/meth_dataset.py
+++ b/methylprep/processing/meth_dataset.py
@@ -2,7 +2,12 @@
 import logging
 import pandas as pd
 # App
-from ..models import METHYLATED_PROBE_SUBSETS, UNMETHYLATED_PROBE_SUBSETS
+from ..models import (
+    METHYLATED_PROBE_SUBSETS,
+    UNMETHYLATED_PROBE_SUBSETS,
+    METHYLATED_SNP_PROBES,
+    UNMETHYLATED_SNP_PROBES,
+)
 
 
 __all__ = ['MethylationDataset']
@@ -25,7 +30,7 @@ class MethylationDataset():
     __preprocessed = False
 
     def __init__(self, raw_dataset, manifest, probe_subsets):
-        LOGGER.info('Preprocessing methylation dataset: %s', raw_dataset.sample)
+        #LOGGER.info('Preprocessing methylation dataset: %s', raw_dataset.sample)
 
         self.probe_subsets = probe_subsets
         self.raw_dataset = raw_dataset
@@ -39,11 +44,23 @@ class MethylationDataset():
 
     @classmethod
     def methylated(cls, raw_dataset, manifest):
+        """ convenience method that feeds in a pre-defined list of methylated CpG locii probes """
         return cls(raw_dataset, manifest, METHYLATED_PROBE_SUBSETS)
 
     @classmethod
     def unmethylated(cls, raw_dataset, manifest):
+        """ convenience method that feeds in a pre-defined list of UNmethylated CpG locii probes """
         return cls(raw_dataset, manifest, UNMETHYLATED_PROBE_SUBSETS)
+
+    @classmethod
+    def snp_methylated(cls, raw_dataset, manifest):
+        """ convenience method that feeds in a pre-defined list of methylated Snp locii probes """
+        return cls(raw_dataset, manifest, METHYLATED_SNP_PROBES)
+
+    @classmethod
+    def snp_unmethylated(cls, raw_dataset, manifest):
+        """ convenience method that feeds in a pre-defined list of methylated Snp locii probes """
+        return cls(raw_dataset, manifest, UNMETHYLATED_SNP_PROBES)
 
     def build_data_frame(self):
         return pd.concat(self.data_frames.values())

--- a/methylprep/processing/postprocess.py
+++ b/methylprep/processing/postprocess.py
@@ -11,7 +11,8 @@ def calculate_beta_value(methylated_noob, unmethylated_noob, offset=100):
     unmethylated = max(unmethylated_noob, 0)
 
     total_intensity = methylated + unmethylated + offset
-    intensity_ratio = methylated / total_intensity
+    with np.errstate(all='raise'):
+        intensity_ratio = methylated / total_intensity
     return intensity_ratio
 
 
@@ -19,7 +20,8 @@ def calculate_m_value(methylated_noob, unmethylated_noob, offset=1):
     methylated = methylated_noob + offset
     unmethylated = unmethylated_noob + offset
 
-    intensity_ratio = np.true_divide(methylated, unmethylated)
+    with np.errstate(all='raise'):
+        intensity_ratio = np.true_divide(methylated, unmethylated)
     return np.log2(intensity_ratio)
 
 
@@ -50,7 +52,7 @@ def consolidate_values_for_sheet(data_containers, postprocess_func_colname='beta
             with all numnpy/pandas functions, or with outside packages, so float64 is default.
             This is specified from methylprep process command line."""
     for idx,sample in enumerate(data_containers):
-        sample_id = "{0}_{1}".format(sample.sample.sentrix_id,sample.sample.sentrix_position)
+        sample_id = f"{sample.sample.sentrix_id}_{sample.sample.sentrix_position}"
         this_sample_values = sample._SampleDataContainer__data_frame[postprocess_func_colname]
         if idx == 0:
             merged = pd.DataFrame(this_sample_values, columns=[postprocess_func_colname])
@@ -61,3 +63,63 @@ def consolidate_values_for_sheet(data_containers, postprocess_func_colname='beta
     if bit != 'float64' and bit in ('float32','float16'):
         merged = merged.astype(bit)
     return merged
+
+
+def consolidate_control_snp(data_containers, control_filename):
+    """saves a pickled dataframe with non-CpG probe values.
+Returns:
+    Control: red and green intensity
+    SNP: beta values, based on uncorrected meth and unmeth intensity.
+    Where
+        0-0.25 ~~ homogyzous-recessive
+        0.25--0.75 ~~ heterozygous
+        0.75--1.00 ~~ homozygous-dominant
+    for each of 50-60 SNP locii on the genome.
+    methylcheck can plot these to genotype samples.
+
+Notes:
+    Each data container has a ctrl_red and ctrl_green dataframe.
+    This shuffles them into a single dictionary of dataframes with keys as Sample_ID matching the meta_data.
+    Where Sample_ID is:
+        {sample.sentrix_id_sample.sentrix_position}
+    and each dataframe contains both the ctrl_red and ctrl_green data. Column names will specify which channel
+    (red or green) the data applies to.
+
+    snp values are stored in container.snp_methylated.data_frame
+    and container.snp_unmethylated.data_frame
+    """
+    out = {}
+    for idx,sample in enumerate(data_containers):
+        sample_id = f"{sample.sample.sentrix_id}_{sample.sample.sentrix_position}"
+        RED = sample.ctrl_red.rename(columns={'mean_value': 'Mean_Value_Red'})
+        GREEN = sample.ctrl_green.rename(columns={'mean_value': 'Mean_Value_Green'})
+        GREEN = GREEN.drop(['Control_Type', 'Color', 'Extended_Type'], axis='columns')
+
+        SNP = sample.snp_methylated.data_frame.rename(columns={'mean_value': 'snp_meth'})
+        SNP_UNMETH = sample.snp_unmethylated.data_frame.rename(columns={'mean_value': 'snp_unmeth'})
+        SNP_UNMETH = SNP_UNMETH.loc[:, ['snp_unmeth']]
+        SNP = pd.merge(SNP, SNP_UNMETH, left_index=True, right_index=True, how='outer')
+        # below (snp-->beta) is analogous to:
+        # SampleDataContainer._postprocess(input_dataframe, calculate_beta_value, 'beta_value')
+        # except that it doesn't use the predefined noob columns.
+        vectorized_func = np.vectorize(calculate_beta_value)
+        SNP['snp_beta'] = vectorized_func(
+            SNP['snp_meth'].values,
+            SNP['snp_unmeth'].values,
+        )
+        SNP = SNP[['snp_beta','snp_meth','snp_unmeth']]
+        SNP = SNP.astype({
+            'snp_meth': 'int32',
+            'snp_unmeth': 'int32'})
+
+        merged = pd.merge(RED, GREEN, left_index=True, right_index=True, how='outer')
+        merged = merged.astype({
+            'Mean_Value_Green': 'int32',
+            'Mean_Value_Red': 'int32'})
+        merged = pd.merge(merged, SNP, left_index=True, right_index=True, how='outer')
+        merged = merged.round({'snp_beta':3})
+        out[sample_id] = merged
+    import pickle
+    with open(control_filename, 'wb') as f:
+        pickle.dump(out, f)
+    return

--- a/methylprep/processing/preprocess.py
+++ b/methylprep/processing/preprocess.py
@@ -80,6 +80,7 @@ def normexp_bg_correct_control(control_probes, params):
 
 
 def apply_bg_correction(mean_values, params):
+    """ this function won't work with float16 in practice. limits use to float32 """
     if not isinstance(params, BackgroundCorrectionParams):
         raise ValueError('params is not a BackgroundCorrectionParams instance')
 

--- a/methylprep/processing/read_geo_processed.py
+++ b/methylprep/processing/read_geo_processed.py
@@ -48,7 +48,8 @@ TODO:
         unmeth = True # need to calculate beta from unmeth/meth columns
         print('Expecting raw meth/unmeth probe data')
     else:
-        meth_pattern = re.compile(r'.*[_ \.]Methylated[_ \.]', re.I)
+        #meth_pattern_v1 = re.compile(r'.*[_ \.]Methylated[_ \.]', re.I)
+        meth_pattern = re.compile(r'.*[_ \.]?(Un)?methylated[_ \.]?', re.I)
         meth_cols = len([col for col in test.columns if re.match(meth_pattern, col)])
         if meth_cols > 0:
             unmeth = True
@@ -120,10 +121,10 @@ TODO:
             vectorized_beta_func = np.vectorize(calculate_beta_value)
             unmeth_samples = []
             meth_samples = []
-            #unmeth_pattern = re.compile(r'.*[_ \.]?Unmethylated[_ \.]?.*', re.I)
-            #meth_pattern = re.compile(r'.*[_ \.]?Methylated[_ \.]?.*', re.I)
-            unmeth_pattern = re.compile(r'.*[_ \.]Unmethylated[_ \.]?', re.I)
-            meth_pattern = re.compile(r'.*[_ \.]Methylated[_ \.]?', re.I)
+            #unmeth_pattern_v1 = re.compile(r'.*[_ \.]Unmethylated[_ \.].*', re.I)
+            #meth_pattern_v1 = re.compile(r'.*[_ \.]Methylated[_ \.].*', re.I)
+            unmeth_pattern = re.compile(r'.*[_ \.]?Unmethylated[_ \.]?', re.I)
+            meth_pattern = re.compile(r'.*[_ \.]?(?<!Un)Methylated[_ \.]?', re.I)
             for col in test.columns:
                 if re.match(unmeth_pattern, col):
                     unmeth_samples.append(col)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='methylprep',
-    version='1.2.1',
+    version='1.2.2',
     description='Python-based Illumina methylation array preprocessing software',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/tests/files/test_manifest.py
+++ b/tests/files/test_manifest.py
@@ -1,6 +1,7 @@
 # App
 from methylprep.files import manifests
 from methylprep.models import ArrayType
+from pathlib import Path
 
 
 class TestManifestConstants():
@@ -15,3 +16,17 @@ class TestManifestConstants():
         assert array_type_filenames[ArrayType.ILLUMINA_450K] == 'HumanMethylation450_15017482_v1-2.CoreColumns.csv.gz'
         assert array_type_filenames[ArrayType.ILLUMINA_EPIC] == 'MethylationEPIC_v-1-0_B4.CoreColumns.csv.gz'
         assert array_type_filenames[ArrayType.ILLUMINA_EPIC_PLUS] == 'CombinedManifestEPIC.manifest.CoreColumns.csv.gz'
+
+    def _control_probe_selection(self):
+        """ checks that control sections of each manifest match the number of probes the model expects.
+        this TEST DOES NOT RUN because it would require downloading all 4 manifest files each time. """
+        array_type_filenames = manifests.ARRAY_TYPE_MANIFEST_FILENAMES # array_type : manifest_filename
+
+        files = {
+            array_type : Path(manifests.MANIFEST_DIR_PATH, manifest_filename).expanduser()
+            for array_type, manifest_filename in array_type_filenames.items()
+            }
+        for array_type, filepath in files.items():
+            man = manifests.Manifest(array_type, filepath)
+            if ArrayType(array_type).num_controls != man._Manifest__control_data_frame.shape[0]:
+                raise AssertionError(f'Control probes found ({man._Manifest__control_data_frame.shape[0]}) in file ({filepath}) does not match expected number: {ArrayType(array_type).num_controls}')

--- a/tests/processing/test_raw_dataset.py
+++ b/tests/processing/test_raw_dataset.py
@@ -1,8 +1,9 @@
 from io import StringIO
 # App
-from methylprep.processing import raw_dataset
-from methylprep.files import SampleSheet
-
+from methylprep.models import Channel, Sample, ArrayType
+from methylprep.processing import raw_dataset, MethylationDataset, RawDataset
+from methylprep.files import SampleSheet, Manifest, IdatDataset
+from pathlib import Path
 
 # TODO:
 # get_raw_datasets(sample_sheet, sample_name=None, from_s3=None)
@@ -13,5 +14,28 @@ class TestRawDataset():
     @staticmethod
     def test_get_raw_dataset_list():
         sample_sheet = SampleSheet('tests/processing/dummy_sheet.csv', '.')
+        # too slow, and done elsewhere already as part of test run_pipeline
         #datasets = raw_dataset.get_raw_datasets(sample_sheet, sample_name=['Sample_1','Sample_2'], from_s3=None)
         #print(datasets)
+
+    @staticmethod
+    def test_methylation_dataset_control_snp():
+        data_dir = 'docs/example_data/GSE69852'
+        sample = Sample(data_dir, '9247377093', 'R02C01')
+        red_idat = IdatDataset(Path(data_dir, '9247377093_R02C01_Red.idat'), Channel.RED)
+        green_idat = IdatDataset(Path(data_dir,'9247377093_R02C01_Grn.idat'), Channel.GREEN)
+        raw_dataset = RawDataset(sample, green_idat, red_idat)
+        manifest = Manifest(ArrayType.ILLUMINA_450K) # this could be REALLY slow, if docker/test env has to download it.
+        fg_controls = raw_dataset.get_fg_controls(manifest, Channel.GREEN)
+        if fg_controls.loc[27630314].mean_value != 299.0:
+            raise AssertionError("fg_controls failed")
+        meth_data = MethylationDataset.snp_methylated(raw_dataset, manifest)
+        if meth_data.data_frame.loc['rs1019916'].mean_value != 7469.0:
+            raise AssertionError("SNP meth failed")
+        if meth_data.data_frame.shape[0] != 65:
+            raise AssertionError("SNP meth failed: unexpected number of SNP probes found")
+        unmeth_data = MethylationDataset.snp_unmethylated(raw_dataset, manifest)
+        if unmeth_data.data_frame.loc['rs1019916'].mean_value != 5291.0:
+            raise AssertionError("SNP unmeth failed")
+        if unmeth_data.data_frame.shape[0] != 65:
+            raise AssertionError("SNP unmeth failed: unexpected number of SNP probes found")


### PR DESCRIPTION
This `--save_control` option will produce a new file, `control_probes.pkl`-- a dict of dataframes keyed to sample names. Each dataframe includes the control probes and Snp probes for each sample. Control probe values are stored as red and green intensities. Snp probes are stored as beta_values (0 to 1).